### PR TITLE
changed timezone region from Germany to Berlin

### DIFF
--- a/src/settings.json
+++ b/src/settings.json
@@ -4,7 +4,7 @@
             "timezone" : "Europe/Budapest"
         },
         "mazawa" : {
-            "timezone" : "Europe/Germany"
+            "timezone" : "Europe/Berlin"
         },
         "matty" : {
             "timezone" : "Asia/Dubai"


### PR DESCRIPTION
Europe/Germany is not a timezone recognized by gettz(), so whenever
the program executed for user "mazawa", it would return the local time
instead of the time in Germany.

Use Europe/Berlin instead to fix the bug.